### PR TITLE
bug fix: changes to support formatting of autodetermination response.

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -37,7 +37,7 @@
         "name": "gpt-4o",
         "version": "2024-08-06",
         "skuName": "Standard",
-        "capacity": 25
+        "capacity": 50
       }
     },
     "reasoningModel": {
@@ -45,7 +45,7 @@
         "name": "o1",
         "version": "2024-12-17",
         "skuName": "GlobalStandard",
-        "capacity": 25
+        "capacity": 50
       }
     },
     "embeddingModel": {

--- a/src/pipeline/promptEngineering/prompt_manager.py
+++ b/src/pipeline/promptEngineering/prompt_manager.py
@@ -208,3 +208,19 @@ class PromptManager:
             query=query,
             SearchResults=search_results,
         )
+
+    def create_prompt_transform_determination_markdown_user(
+        self,
+        autodetermination_text: str
+    ) -> str:
+        return self.get_prompt(
+            "transform_determination_markdown_user_prompt.jinja",
+            autodetermination_text=autodetermination_text
+        )
+
+    def create_prompt_transform_determination_markdown_system(
+        self
+    ) -> str:
+        return self.get_prompt(
+            "transform_determination_markdown_system_prompt.jinja"
+        )

--- a/src/pipeline/promptEngineering/templates/transform_determination_markdown_system_prompt.jinja
+++ b/src/pipeline/promptEngineering/templates/transform_determination_markdown_system_prompt.jinja
@@ -1,0 +1,3 @@
+## Role:
+
+You are a text transformation assistant whose primary goal is to format the provided text into Markdown compliant text **without altering the user’s original content**.

--- a/src/pipeline/promptEngineering/templates/transform_determination_markdown_user_prompt.jinja
+++ b/src/pipeline/promptEngineering/templates/transform_determination_markdown_user_prompt.jinja
@@ -1,0 +1,18 @@
+## Role:
+
+You are a text transformation assistant whose primary goal is to format a user’s text into Markdown compliant text **without altering the user’s original content**.
+
+## Task:
+
+As part of the text transformation, you must do the following:
+
+1. **Preserve the user’s text exactly** as given (no changes to words or meaning or order).
+2. **Add or correct Markdown formatting** so that the final output is consistent with markdown formatting.
+3. Use **bold text**, **bullet points**, and **section headings** as appropriate.
+4. Only **add formatting** (e.g., headings, bold, lists) – do **not** remove or rephrase any original sentences or content.
+
+If the original text is already in Markdown text, do nothing and pass the input through as the output, as is.
+
+## Transform the text:
+
+{{ autodetermination_text }}


### PR DESCRIPTION
# Project Enhancement Request

## Description

`o1` model has subtle differences in the prompt response to `o1-preview`, this PR takes an approach to protect the prompt research and design in favor of formatting the autodetermination response in the front end display.

Radio button is built in to support the transparency in feature.

## Type of Change

Please select the relevant option(s) and delete those that are not applicable:

- [x] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that introduces functionality)
- [ ] Breaking change (fix or feature causing existing functionality to break)
- [ ] Azure AI service integration (Specify: Cognitive Services, Machine Learning, etc.)
- [ ] Code optimization or technical debt resolution
- [ ] Documentation update required for the changes

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have successfully executed and passed all new and existing tests and checks relevant to the project.
- [ ] I have updated the documentation if necessary.
- [x] I have tested the changes in an environment representative of the deployment environment.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have opened an Issue reporting a Bug, New Feature, Breaking Change, and/or Documentation Update (https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue).

## Azure AI Service Integration Details (if applicable):

- [ ] I have integrated a new Azure AI service.
- [ ] I have updated the configuration or usage of an existing Azure AI service.
- [ ] The integration has been tested and documented.
- [ ] Changes to the integration are backwards-compatible with previous versions.

## Context

New UI looks like the following:

<img width="1686" alt="image" src="https://github.com/user-attachments/assets/1748cbf4-c85d-4089-bf49-77e3076d646a" />
