### PR TITLE
azure monitoring duplicate dependency in requirements.txt and limited…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ azure-ai-evaluation==1.2.0
 azure-cosmos==4.7.0
 azure-search-documents==11.6.0b5
 azure-storage-blob==12.23.1
-azure-monitor-opentelemetry==1.6.4
+azure-monitor-opentelemetry==1.6.7
 
 # LLM Metrics
 ragas==0.2.3
@@ -57,7 +57,6 @@ asyncio==3.4.3
 tenacity==8.5.0
 
 semantic_kernel
-azure-monitor-opentelemetry
 azure-ai-inference[opentelemetry]
 opentelemetry-exporter-otlp
 azure-ai-projects

--- a/utils/azd/hooks/postdeploy.ps1
+++ b/utils/azd/hooks/postdeploy.ps1
@@ -40,10 +40,10 @@ if (-not $jobExists) {
     az acr login --name $acr_endpoint
 
     Write-Info "Updating container app job image..."
-    $null = & az containerapp job update -g $rg_name --name $job_name --image $frontend_image 2>&1
+    $null = & az containerapp job update -g $rg_name --name $job_name --image $frontend_image --cpu 2 --memory 4Gi 2>&1
 
     Write-Info "Starting job $job_name..."
-    az containerapp job start -g $rg_name --name $job_name
+    az containerapp job start -g $rg_name --name $job_name --cpu 2 --memory 4Gi
 
     Write-Info "Waiting for job to complete..."
     $status = "Running"

--- a/utils/azd/hooks/postdeploy.sh
+++ b/utils/azd/hooks/postdeploy.sh
@@ -95,10 +95,11 @@ update_and_run_job() {
     az acr login --name "$acr_endpoint"
 
     log_info "Updating container app job image..."
-    az containerapp job update -g "$rg_name" --name "$job_name" --image "$frontend_image"
+    az containerapp job update -g "$rg_name" --name "$job_name" --image "$frontend_image" \
+        --cpu 2.0 --memory 4.0
 
     log_info "Starting job $job_name..."
-    az containerapp job start -g "$rg_name" --name "$job_name"
+    az containerapp job start -g "$rg_name" --name "$job_name" --cpu 2.0 --memory 4.0
 
     log_info "Waiting for job to complete..."
     status="Running"


### PR DESCRIPTION
This pull request updates the resource allocation for container app jobs in both PowerShell and Bash deployment scripts. The changes ensure that jobs are configured with specific CPU and memory limits during updates and when starting.

Resource allocation updates:

* [`utils/azd/hooks/postdeploy.ps1`](diffhunk://#diff-eeaf669eb96c6ff00b52ce16c43634d9eff5a4875cd8fbf992567d163a62aa50L43-R46): Modified the `az containerapp job update` and `az containerapp job start` commands to include `--cpu 2` and `--memory 4Gi` parameters, setting the CPU to 2 cores and memory to 4 GiB.
* [`utils/azd/hooks/postdeploy.sh`](diffhunk://#diff-062cfc18ef328d9582d36a5cd41ed23ca05a5925faaf988accc023518b59163aL98-R102): Updated the `az containerapp job update` and `az containerapp job start` commands to include `--cpu 2.0` and `--memory 4.0`, ensuring consistent resource allocation in the Bash script.