### PR TITLE
Update links in README.md to point to the current gh docs page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ utils/data/cases/001/a/tmp/01_a_form.pdf
 .azure
 cleanup.sh
 docker-build.sh
+*.rest

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 🚀 **Welcome! Ready to streamline your Prior Authorization process?** Click below to get started with your deployment and unlock the full potential of AutoAuth.
 
 <div align="center">
-    <a href="https://pablosalvador10.github.io/gbb-ai-hls-factory-prior-auth/azd_deployment.html">
+    <a href="https://azure-samples.github.io/autoauth-solution-accelerator/azd_deployment.html">
         <img src="https://img.shields.io/badge/🚀%20Click Me-Deploy%20To%20Azure-blue?style=for-the-badge&logo=github&logoWidth=20" alt="📚 Wiki" height="32">
     </a>
     </a>
@@ -21,7 +21,7 @@
 - [Overview](#-overview)
 - [Introducing AutoAuth](#-introducing-autoauth)
 - [Quick Start](#-quick-start)
-    - [End-to-End Deployment Using AZD](https://pablosalvador10.github.io/gbb-ai-hls-factory-prior-auth/azd_deployment.html)
+    - [End-to-End Deployment Using AZD](https://azure-samples.github.io/autoauth-solution-accelerator/azd_deployment.html)
     - [PriorAuth SDK](#priorauth-sdk)
     - [Evaluations Framework](#evaluations)
 - [What's Next?](#-whats-next)
@@ -61,7 +61,7 @@ This repository aims to **streamline and automate** the PA process using Azure A
   </p>
 </div>
 
-**Note:** For comprehensive details, including technical architecture, customization steps, references, and additional documentation, please visit our **[GitHub Pages](https://pablosalvador10.github.io/gbb-ai-hls-factory-prior-auth)**.
+**Note:** For comprehensive details, including technical architecture, customization steps, references, and additional documentation, please visit our **[GitHub Pages](https://azure-samples.github.io/autoauth-solution-accelerator)**.
 
 <div align="center">
   <a href="https://player.vimeo.com/video/1040993686?h=f9c8e5ffba">
@@ -78,7 +78,7 @@ This repository aims to **streamline and automate** the PA process using Azure A
 
 > [!TIP]
 > *Want to customize or learn more about configuration?*
-> **[Read the detailed instructions on our GitHub Pages ➜](https://pablosalvador10.github.io/gbb-ai-hls-factory-prior-auth)**
+> **[Read the detailed instructions on our GitHub Pages ➜](https://azure-samples.github.io/autoauth-solution-accelerator)**
 
 More detailed documentation can be found in [docs/azd_deployment.md](docs/azd_deployment.md).
 
@@ -112,7 +112,7 @@ For those looking for greater flexibility, the AutoAuth SDK enables you to embed
 
 With the AutoAuth SDK, you have the flexibility to automate end-to-end Prior Authorization workflows or select specific components to integrate into your system. Whether you require a full application or a microservice solution, AutoAuth provides the tools you need.
 
-**Note:** Detailed information, technical architecture, customization steps, references, and further documentation are available on our **[GitHub Pages](https://pablosalvador10.github.io/gbb-ai-hls-factory-prior-auth)**.
+**Note:** Detailed information, technical architecture, customization steps, references, and further documentation are available on our **[GitHub Pages](https://azure-samples.github.io/autoauth-solution-accelerator)**.
 
 ### Evaluations
 


### PR DESCRIPTION
This pull request updates the `README.md` file to replace outdated links with new ones pointing to the updated GitHub Pages for the AutoAuth solution accelerator. This ensures users are directed to the correct and current documentation and deployment resources.

### Link Updates in `README.md`:

* Updated the deployment button link to point to the new GitHub Pages URL for AutoAuth.
* Replaced the "End-to-End Deployment Using AZD" link in the Quick Start section with the updated URL.
* Updated the GitHub Pages link in the "Note" section for comprehensive details and documentation.
* Updated the GitHub Pages link in the "TIP" section for detailed instructions.
* Updated the GitHub Pages link in the "Note" under the AutoAuth SDK section for detailed information and resources.