### PR TITLE
Remove 'statisticsEnabled' property from AI service configuration in Bicep files

### DIFF
--- a/infra/modules/ai/docintelligence.bicep
+++ b/infra/modules/ai/docintelligence.bicep
@@ -26,7 +26,6 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
     publicNetworkAccess: 'Enabled'
     disableLocalAuth: false
     apiProperties: {
-      statisticsEnabled: false
     }
     customSubDomainName: aiServiceNameCleaned
   }

--- a/infra/modules/ai/mais.bicep
+++ b/infra/modules/ai/mais.bicep
@@ -26,7 +26,6 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
     publicNetworkAccess: 'Enabled'
     disableLocalAuth: false
     apiProperties: {
-      statisticsEnabled: false
     }
     customSubDomainName: aiServiceNameCleaned
   }

--- a/infra/modules/ai/openai.bicep
+++ b/infra/modules/ai/openai.bicep
@@ -46,7 +46,6 @@ resource openAiService 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
     publicNetworkAccess: 'Enabled'
     disableLocalAuth: false
     apiProperties: {
-      statisticsEnabled: false
     }
     customSubDomainName: aiServiceNameCleaned
   }


### PR DESCRIPTION
statisticsenabled attribute for cognitive services bicep template is throwing an invalid template error. Removing for now